### PR TITLE
Fix DCL-UI Issue 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-ui",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A Vuejs based application for managing CSA Distributed Compliance Ledger",
   "author": "Comcast Inc.",
   "private": true,

--- a/src/views/Compliance/Compliance.vue
+++ b/src/views/Compliance/Compliance.vue
@@ -167,16 +167,20 @@ export default {
 				return value
 		},
 		populateModelData(complianceArray, allComplianceInfo) {
-			complianceArray?.forEach((certifiedModel) => {
-				const complianceInfo = allComplianceInfo?.find((complianceInfo) => {
-					return complianceInfo.vid === certifiedModel.vid && complianceInfo.pid === certifiedModel.pid;
-				});
-				if (complianceInfo) {
-					certifiedModel.softwareVersionString = complianceInfo.softwareVersionString;
-					certifiedModel.cDCertificateId = complianceInfo.cDCertificateId;
-				}
-			});
-  	},
+      if (!allComplianceInfo || allComplianceInfo.length === 0) {
+          return;
+      }
+      for (const certifiedModel of complianceArray || []) {
+          const { vid, pid, softwareVersion } = certifiedModel;
+          const complianceInfo = allComplianceInfo.find((complianceInfo) => {
+              return complianceInfo.vid === vid && complianceInfo.pid === pid && complianceInfo.softwareVersion === softwareVersion;
+          });
+          if (complianceInfo) {
+              certifiedModel.softwareVersionString = complianceInfo.softwareVersionString;
+              certifiedModel.cDCertificateId = complianceInfo.cDCertificateId;
+          }
+      }
+    },
 	}
 }
 </script>


### PR DESCRIPTION
Currently when matching the records to get the CDCertificationID, the match was done for vid/pid, which work only if there are no more than one softwareVersion for the model. Fixed the defect by also matching softwareVersion.

This PR fixes #26 