### PR TITLE
Replace numeric literals with underscores for ES compatibility

### DIFF
--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/authz.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/authz.js
@@ -125,13 +125,13 @@ export const Grant = {
     }
 };
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/authz.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/authz.ts
@@ -162,14 +162,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/genesis.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/genesis.js
@@ -169,13 +169,13 @@ export const GrantAuthorization = {
     }
 };
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/genesis.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/cosmos/authz/v1beta1/genesis.ts
@@ -198,14 +198,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/abci/types.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/abci/types.js
@@ -4516,13 +4516,13 @@ function base64FromBytes(arr) {
     return btoa(bin.join(''));
 }
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/abci/types.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/abci/types.ts
@@ -4910,14 +4910,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/types/types.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/types/types.js
@@ -1565,13 +1565,13 @@ function base64FromBytes(arr) {
     return btoa(bin.join(''));
 }
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/types/types.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.authz.v1beta1/module/types/tendermint/types/types.ts
@@ -1693,14 +1693,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.evidence.v1beta1/module/types/cosmos/evidence/v1beta1/evidence.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.evidence.v1beta1/module/types/cosmos/evidence/v1beta1/evidence.js
@@ -123,13 +123,13 @@ var globalThis = (() => {
     throw 'Unable to locate global object';
 })();
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.evidence.v1beta1/module/types/cosmos/evidence/v1beta1/evidence.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.evidence.v1beta1/module/types/cosmos/evidence/v1beta1/evidence.ts
@@ -144,14 +144,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.feegrant.v1beta1/module/types/cosmos/feegrant/v1beta1/feegrant.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.feegrant.v1beta1/module/types/cosmos/feegrant/v1beta1/feegrant.js
@@ -386,13 +386,13 @@ export const Grant = {
     }
 };
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.feegrant.v1beta1/module/types/cosmos/feegrant/v1beta1/feegrant.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.feegrant.v1beta1/module/types/cosmos/feegrant/v1beta1/feegrant.ts
@@ -463,14 +463,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.gov.v1beta1/module/types/cosmos/gov/v1beta1/gov.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.gov.v1beta1/module/types/cosmos/gov/v1beta1/gov.js
@@ -1038,13 +1038,13 @@ function base64FromBytes(arr) {
     return btoa(bin.join(''));
 }
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.gov.v1beta1/module/types/cosmos/gov/v1beta1/gov.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.gov.v1beta1/module/types/cosmos/gov/v1beta1/gov.ts
@@ -1154,14 +1154,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.slashing.v1beta1/module/types/cosmos/slashing/v1beta1/slashing.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.slashing.v1beta1/module/types/cosmos/slashing/v1beta1/slashing.js
@@ -301,13 +301,13 @@ function base64FromBytes(arr) {
     return btoa(bin.join(''));
 }
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.slashing.v1beta1/module/types/cosmos/slashing/v1beta1/slashing.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.slashing.v1beta1/module/types/cosmos/slashing/v1beta1/slashing.ts
@@ -345,14 +345,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/staking.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/staking.js
@@ -1927,13 +1927,13 @@ var globalThis = (() => {
     throw 'Unable to locate global object';
 })();
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/staking.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/staking.ts
@@ -2180,14 +2180,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/tx.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/tx.js
@@ -794,13 +794,13 @@ export class MsgClientImpl {
     }
 }
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/tx.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/cosmos/staking/v1beta1/tx.ts
@@ -928,14 +928,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/tendermint/types/types.js
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/tendermint/types/types.js
@@ -1565,13 +1565,13 @@ function base64FromBytes(arr) {
     return btoa(bin.join(''));
 }
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/tendermint/types/types.ts
+++ b/src/store/generated/cosmos/cosmos-sdk/cosmos.staking.v1beta1/module/types/tendermint/types/types.ts
@@ -1693,14 +1693,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/cosmos/ibc-go/ibc.applications.transfer.v1/module/types/cosmos/upgrade/v1beta1/upgrade.js
+++ b/src/store/generated/cosmos/ibc-go/ibc.applications.transfer.v1/module/types/cosmos/upgrade/v1beta1/upgrade.js
@@ -282,13 +282,13 @@ var globalThis = (() => {
     throw 'Unable to locate global object';
 })();
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/cosmos/ibc-go/ibc.applications.transfer.v1/module/types/cosmos/upgrade/v1beta1/upgrade.ts
+++ b/src/store/generated/cosmos/ibc-go/ibc.applications.transfer.v1/module/types/cosmos/upgrade/v1beta1/upgrade.ts
@@ -342,14 +342,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 

--- a/src/store/generated/zigbee-alliance/distributed-compliance-ledger/zigbeealliance.distributedcomplianceledger.dclupgrade/module/types/cosmos/upgrade/v1beta1/upgrade.js
+++ b/src/store/generated/zigbee-alliance/distributed-compliance-ledger/zigbeealliance.distributedcomplianceledger.dclupgrade/module/types/cosmos/upgrade/v1beta1/upgrade.js
@@ -372,13 +372,13 @@ var globalThis = (() => {
     throw 'Unable to locate global object';
 })();
 function toTimestamp(date) {
-    const seconds = date.getTime() / 1_000;
-    const nanos = (date.getTime() % 1_000) * 1_000_000;
+    const seconds = date.getTime() / 1000;
+    const nanos = (date.getTime() % 1000) * 1000000;
     return { seconds, nanos };
 }
 function fromTimestamp(t) {
-    let millis = t.seconds * 1_000;
-    millis += t.nanos / 1_000_000;
+    let millis = t.seconds * 1000;
+    millis += t.nanos / 1000000;
     return new Date(millis);
 }
 function fromJsonTimestamp(o) {

--- a/src/store/generated/zigbee-alliance/distributed-compliance-ledger/zigbeealliance.distributedcomplianceledger.dclupgrade/module/types/cosmos/upgrade/v1beta1/upgrade.ts
+++ b/src/store/generated/zigbee-alliance/distributed-compliance-ledger/zigbeealliance.distributedcomplianceledger.dclupgrade/module/types/cosmos/upgrade/v1beta1/upgrade.ts
@@ -455,14 +455,14 @@ export type DeepPartial<T> = T extends Builtin
   : Partial<T>
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000
-  const nanos = (date.getTime() % 1_000) * 1_000_000
+  const seconds = date.getTime() / 1000
+  const nanos = (date.getTime() % 1000) * 1000000
   return { seconds, nanos }
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000
-  millis += t.nanos / 1_000_000
+  let millis = t.seconds * 1000
+  millis += t.nanos / 1000000
   return new Date(millis)
 }
 


### PR DESCRIPTION
Replaced numeric literals containing underscores with their non-underscore equivalents for backward compatibility.