### PR TITLE
Fix CosmJS version mismatch causing base64 encoding errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "dcl-ui",
-      "version": "1.14.12",
+      "version": "1.15.0",
       "dependencies": {
         "@chainapsis/cosmosjs": "^0.0.3-alpha.3",
         "@cosmjs/launchpad": "^0.27.1",
@@ -20,7 +20,7 @@
         "@vuelidate/validators": "^2.0.4",
         "bip39": "^3.0.4",
         "buffer": "^6.0.3",
-        "chart.js": "3.3.2",
+        "chart.js": "^3.3.2",
         "core-js": "^3.11.2",
         "crypto-browserify": "^3.12.0",
         "crypto-js": "^4.0.0",
@@ -7727,12 +7727,13 @@
       "link": true
     },
     "ts-client": {
+      "name": "zigbee-alliance-distributed-compliance-ledger-client-ts",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/launchpad": "0.27.0",
-        "@cosmjs/proto-signing": "0.27.0",
-        "@cosmjs/stargate": "0.27.0",
+        "@cosmjs/launchpad": "0.27.1",
+        "@cosmjs/proto-signing": "0.32.3",
+        "@cosmjs/stargate": "0.32.3",
         "@keplr-wallet/types": "^0.11.3",
         "axios": "0.21.4",
         "buffer": "^6.0.3",
@@ -7743,206 +7744,10 @@
         "typescript": "^4.8.4"
       },
       "peerDependencies": {
-        "@cosmjs/launchpad": "0.27.0",
-        "@cosmjs/proto-signing": "0.27.0",
-        "@cosmjs/stargate": "0.27.0"
+        "@cosmjs/launchpad": "0.27.1",
+        "@cosmjs/proto-signing": "0.32.3",
+        "@cosmjs/stargate": "0.32.3"
       }
-    },
-    "ts-client/node_modules/@cosmjs/amino": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.27.0.tgz",
-      "integrity": "sha512-ybyzRkGrRija1bjGjGP7sAp2ulPA2/S2wMY2pehB7b6ZR8dpwveCjz/IqFWC5KBxz6KZf5MuaONOY+t1kkjsfw==",
-      "dependencies": {
-        "@cosmjs/crypto": "0.27.0",
-        "@cosmjs/encoding": "0.27.0",
-        "@cosmjs/math": "0.27.0",
-        "@cosmjs/utils": "0.27.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/crypto": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.27.0.tgz",
-      "integrity": "sha512-JTPHINCYZ+mnsxrfv8ZBHsFWgB7EGooa5SD0lQFhkCVX/FC3sqxuFNv6TZU5bVVU71DUSqXTMXF5m9kAMzPUkw==",
-      "dependencies": {
-        "@cosmjs/encoding": "0.27.0",
-        "@cosmjs/math": "0.27.0",
-        "@cosmjs/utils": "0.27.0",
-        "bip39": "^3.0.2",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.3",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/encoding": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.27.0.tgz",
-      "integrity": "sha512-cCT8X/NUAGXOe14F/k2GE6N9btjrOqALBilUPIn5CL4OEGxvRTPD59nWSACu0iafCGz10Tw3LPcouuYPtZmkbg==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/json-rpc": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.27.0.tgz",
-      "integrity": "sha512-Q6na5KPYDD90QhlPZTInquwBycDjvhZvWwpV1TppDd2Em8S1FfN3ePiV2YCf4XzXREU5YPFSHzh5MHK/WhQY3w==",
-      "dependencies": {
-        "@cosmjs/stream": "0.27.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/launchpad": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/launchpad/-/launchpad-0.27.0.tgz",
-      "integrity": "sha512-V8pK3jNvLw/2jf0DK0uD0fN0qUgh+v04NxSNIdRxyn2sdZ8CkD1L+FeKM5mGEn9vreSHOD4Z9pRy2s2roD/tEw==",
-      "dependencies": {
-        "@cosmjs/amino": "0.27.0",
-        "@cosmjs/crypto": "0.27.0",
-        "@cosmjs/encoding": "0.27.0",
-        "@cosmjs/math": "0.27.0",
-        "@cosmjs/utils": "0.27.0",
-        "axios": "^0.21.2",
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/math": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.27.0.tgz",
-      "integrity": "sha512-+WsrdXojqpUL6l2LKOWYgiAJIDD0faONNtnjb1kpS1btSzZe1Ns+RdygG6QZLLvZuxMfkEzE54ZXDKPD5MhVPA==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/proto-signing": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.27.0.tgz",
-      "integrity": "sha512-ODqnmY/ElmcEYu6HbDmeGce4KacgzSVGQzvGodZidC1RR9EYociuweBPNwSHqBPolC6PQPI/QGc83m/mbih2xw==",
-      "dependencies": {
-        "@cosmjs/amino": "0.27.0",
-        "@cosmjs/crypto": "0.27.0",
-        "@cosmjs/math": "0.27.0",
-        "cosmjs-types": "^0.4.0",
-        "long": "^4.0.0",
-        "protobufjs": "~6.10.2"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/proto-signing/node_modules/protobufjs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-      "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/socket": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.27.0.tgz",
-      "integrity": "sha512-lOd0s6gLyjdjcs8xnYuS2IXRqBLUrI76Bek5wsia+m5CyUvHjRbbd7+nZiznbtVjApBlIwHGkiklLg3/byxkAA==",
-      "dependencies": {
-        "@cosmjs/stream": "0.27.0",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/stargate": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.27.0.tgz",
-      "integrity": "sha512-Fiqk8rIpB4emzC/P7/+ZPPJV9aG6KJhVuOF4D8c1j1Bv8fVs1XqC6NgsY6elTLXl38pgXt7REn6VYzAdZwrHXQ==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.3",
-        "@cosmjs/amino": "0.27.0",
-        "@cosmjs/encoding": "0.27.0",
-        "@cosmjs/math": "0.27.0",
-        "@cosmjs/proto-signing": "0.27.0",
-        "@cosmjs/stream": "0.27.0",
-        "@cosmjs/tendermint-rpc": "0.27.0",
-        "@cosmjs/utils": "0.27.0",
-        "cosmjs-types": "^0.4.0",
-        "long": "^4.0.0",
-        "protobufjs": "~6.10.2",
-        "xstream": "^11.14.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/stargate/node_modules/protobufjs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-      "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/stream": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.27.0.tgz",
-      "integrity": "sha512-D9mXHqS6y7xrThhUg5SCvMjiVQ8ph9f7gAuWlrXhqVJ5FqrP6OyTGRbVyGGM91d5Jj7N7oidQ+hOfc34vKFgeg==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.27.0.tgz",
-      "integrity": "sha512-WFcJ2/UF76fBBVzPRiHJoC/GCKvgt0mb7+ewgpwKBeEcYwfj5qb1QreGBbHn/UZx9QSsF9jhI5k7SmNdglC3cA==",
-      "dependencies": {
-        "@cosmjs/crypto": "0.27.0",
-        "@cosmjs/encoding": "0.27.0",
-        "@cosmjs/json-rpc": "0.27.0",
-        "@cosmjs/math": "0.27.0",
-        "@cosmjs/socket": "0.27.0",
-        "@cosmjs/stream": "0.27.0",
-        "axios": "^0.21.2",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/utils": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.27.0.tgz",
-      "integrity": "sha512-UC1eWY9isDQm6POy6GaTmYtbPVY5dkywdjW8Qzj+JNMhbhMM0KHuI4pHwjv5TPXSO/Ba2z10MTnD9nUlZtDwtA=="
-    },
-    "ts-client/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
     },
     "ts-client/node_modules/axios": {
       "version": "0.21.4",
@@ -7950,15 +7755,6 @@
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
-      }
-    },
-    "ts-client/node_modules/cosmjs-types": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.4.1.tgz",
-      "integrity": "sha512-I7E/cHkIgoJzMNQdFF0YVqPlaTqrqKHrskuSTIqlEyxfB5Lf3WKCajSXVK2yHOfOFfSux/RxEdpMzw/eO4DIog==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
       }
     },
     "ts-client/node_modules/follow-redirects": {

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -15,18 +15,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@cosmjs/launchpad": "0.27.0",
-    "@cosmjs/proto-signing": "0.27.0",
-    "@cosmjs/stargate": "0.27.0",
-    "@keplr-wallet/types": "^0.11.3", 
+    "@cosmjs/launchpad": "0.27.1",
+    "@cosmjs/proto-signing": "0.32.3",
+    "@cosmjs/stargate": "0.32.3",
+    "@keplr-wallet/types": "^0.11.3",
     "axios": "0.21.4",
     "buffer": "^6.0.3",
     "events": "^3.3.0"
   },
   "peerDependencies": {
-    "@cosmjs/launchpad": "0.27.0",
-    "@cosmjs/proto-signing": "0.27.0",
-    "@cosmjs/stargate": "0.27.0"
+    "@cosmjs/launchpad": "0.27.1",
+    "@cosmjs/proto-signing": "0.32.3",
+    "@cosmjs/stargate": "0.32.3"
   }, 
   "devDependencies": {
     "@types/events": "^3.0.0",


### PR DESCRIPTION
Update ts-client package.json to use CosmJS versions matching root:
- @cosmjs/proto-signing: 0.27.0 -> 0.32.3
- @cosmjs/stargate: 0.27.0 -> 0.32.3
- @cosmjs/launchpad: 0.27.0 -> 0.27.1

This resolves "Invalid base64 string format" errors in production builds caused by incompatible transaction encoding/decoding between different CosmJS versions.