### PR TITLE
Fix public key @type format for CLI compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-ui",
-  "version": "1.15.1",
+  "version": "1.15.3",
   "description": "A Vuejs based application for managing CSA Distributed Compliance Ledger",
   "author": "Comcast Inc.",
   "private": true,

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -244,7 +244,7 @@
                             </button>
                         </div>
                         <div class="text-900 font-medium text-lg">
-                            Public Key :
+                            CLI Public Key :
                             <span class="text-500 font-medium">{{ shortenKey(cliFormatPubKey) }}</span>
                             <button
                                 @click="copyToClipboard(cliFormatPubKey)"


### PR DESCRIPTION
The cliFormatPubKey computed property was using this.pubKey.type which returns 'tendermint/PubKeySecp256k1' from the decodePubkey function. This caused the public key format to be inconsistent with dcld CLI output.

Hardcoded @type to '/cosmos.crypto.secp256k1.PubKey' to match the expected CLI format and maintain consistency with dcld commands.