### PR TITLE
Fix ModelInfo field labels to match specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-ui",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "A Vuejs based application for managing CSA Distributed Compliance Ledger",
   "author": "Comcast Inc.",
   "private": true,

--- a/src/views/Models/ModelInfo.vue
+++ b/src/views/Models/ModelInfo.vue
@@ -266,7 +266,7 @@ export default {
                     <td>{{ selectedModel.enhancedSetupFlowTCFileSize }}</td>
                 </tr>
                 <tr>
-                    <td>Maintenance URL</td>
+                    <td>Enhanced Setup Flow Maintenance URL</td>
                     <td>{{ selectedModel.maintenanceUrl }}</td>
                 </tr>
                 <tr>
@@ -588,13 +588,13 @@ export default {
                     <!-- Field for maintenanceUrl -->
                     <div class="field">
                         <label for="maintenanceUrl">
-                            <IconField v-tooltip.top="'URL for maintenance details'">
-                                Maintenance URL
+                            <IconField v-tooltip.top="'Enhanced Setup Flow Maintenance URL details'">
+                                Enhanced Setup Flow Maintenance URL
                                 <i class="pi pi-info-circle ml-2"></i>
                             </IconField>
                         </label>
                         <InputText id="maintenanceUrl" type="text" v-model="v$.model.maintenanceUrl.$model" :class="{ 'p-invalid': v$.model.maintenanceUrl.$invalid && submitted }" />
-                        <div v-if="v$.model.maintenanceUrl.$invalid && submitted" class="p-error">Maintenance URL is invalid</div>
+                        <div v-if="v$.model.maintenanceUrl.$invalid && submitted" class="p-error">Enhanced Setup Flow Maintenance URL is invalid</div>
                     </div>
 
                     <!-- Field for discoverCapabilitiesBitmask -->
@@ -614,7 +614,7 @@ export default {
                     <!-- Field for schemaVersion -->
                     <div class="field">
                         <label for="schemaVersion">
-                            <IconField v-tooltip.top="'Schema version to support backward/forward compatibility (default 1)'">
+                            <IconField v-tooltip.top="'Schema version to support backward/forward compatibility (default 0)'">
                                 Schema Version
                                 <i class="pi pi-info-circle ml-2"></i>
                             </IconField>


### PR DESCRIPTION
### Changes
- Corrected Schema Version tooltip from "(default 1)" to "(default 0)" to align with the specification
- Renamed "Maintenance URL" field to "Enhanced Setup Flow Maintenance URL" in both view-only and form sections to match spec terminology

### Context
The Schema Version field was displaying an incorrect default value in the tooltip that contradicted both the specification (which only specifies schema version = 0) and the code implementation (which initializes `schemaVersion` to 0).

The Maintenance URL field label was incomplete and has been updated to the full specification name "Enhanced Setup Flow Maintenance URL" for consistency and clarity.

### Files Changed
- `src/views/Models/ModelInfo.vue`